### PR TITLE
platform/ssh/daemon - Removed hmac-ripemd160-etm@openssh.com and hmac…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 # **[Unreleased](https://github.com/travisperkins/artemis/compare/v2.0.0...HEAD) (HEAD)**
 
+### platform/ssh/daemon
+- **Remove**: **hmac-ripemd160-etm@openssh.com** and **hmac-ripemd160** MAC algorithms due to them being deprecated - [Richard Lees]
+
 <!------------------------------------------------------------------------------------------------>
 
 # **[v2.0.0](https://github.com/travisperkins/artemis/compare/v1.5.2...v2.0.0) (August 17, 2017)**

--- a/platform/ssh/daemon/defaults/main.yml
+++ b/platform/ssh/daemon/defaults/main.yml
@@ -51,7 +51,7 @@ sshd_challengeresponseauthentication: '{{ sshd_false }}'
 
 ###################################################################################################
 
-sshd_macs                  : hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,umac-64-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com,umac-64@openssh.com,hmac-sha1
+sshd_macs                  : hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,umac-64-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,umac-64@openssh.com,hmac-sha1
 sshd_banner                : '{{ issue_net_dest }}'
 sshd_usedns                : '{{ sshd_false     }}'
 sshd_usepam                : '{{ sshd_true      }}'

--- a/platform/ssh/daemon/vars/security-balanced
+++ b/platform/ssh/daemon/vars/security-balanced
@@ -7,7 +7,7 @@ sshd_hostkeys:
 
 ###################################################################################################
 
-sshd_macs               : hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com
+sshd_macs               : hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
 sshd_usedns             : '{{ sshd_true }}'
 sshd_ciphers            : chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com
 sshd_loglevel           : VERBOSE


### PR DESCRIPTION
Removal of the following MAC algorithms for SSH daemon:

- hmac-ripemd160-etm@openssh.com
- hmac-ripemd160

They are deprecated and in OpenSSH 7.6 that has now been released having these MAC algorithms specified in `sshd_config` will stop SSH daemon from starting.

[OpenSSH 7.6 Release Notes](https://www.openssh.com/txt/release-7.6)

I suggest making the change to drop these MAC algorithms across all OS and distributions rather than just the ones running OpenSSH 7.6+ as they are not commonly used MAC algorithms that have probably been deprecated for good reason.