### PR TITLE
platform/motd: allow imports for all operating systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 # **[Unreleased](https://github.com/travisperkins/artemis/compare/v2.0.0...HEAD) (HEAD)**
 
+### platform/motd
+- **Change**: Move family and overrides imports into main tasks rather than debian tasks - [Richard Lees]
+
 ### platform/ntpd
 - **Change**: The discard average value has been changed. By default it is now **3**, for the **balanced** security mode it is now **4** and for the **enhanced** security mode it is now **9** - [Richard Lees]
 - **Change**: The initial manual time sync is now disabled by default. NTPD will take care of making sure the clock is syncronised when it is started. The manual sync can be turned back on by setting **ntpd_set_enabled** to **true** - [Richard Lees]

--- a/platform/motd/tasks/debian.yml
+++ b/platform/motd/tasks/debian.yml
@@ -1,31 +1,5 @@
 ###################################################################################################
 
-- name: debian | import
-
-  include_vars: debian
-
-  tags:
-    - artemis
-    - platform
-    - motd
-    - debian
-
-###################################################################################################
-
-- name: debian | overrides
-
-  when: overrides_verified
-
-  include_vars: '{{ overrides_path }}'
-
-  tags:
-    - artemis
-    - platform
-    - motd
-    - debian
-
-###################################################################################################
-
 - name: debian | pam | sshd
 
   become: true

--- a/platform/motd/tasks/main.yml
+++ b/platform/motd/tasks/main.yml
@@ -1,5 +1,33 @@
 ###################################################################################################
 
+- name: import | family
+
+  include_vars: '{{ item }}'
+
+  with_first_found:
+    - '{{ os_family_lower }}'
+    - '{{ dev_null        }}'
+
+  tags:
+    - artemis
+    - platform
+    - motd
+
+###################################################################################################
+
+- name: import | overrides
+
+  when: overrides_verified
+
+  include_vars: '{{ overrides_path }}'
+
+  tags:
+    - artemis
+    - platform
+    - motd
+
+###################################################################################################
+
 - name: setup
 
   setup:


### PR DESCRIPTION
Rather than making the *family* and *overrides* imports only for Debian-based, make them available for all operating system families.

Reasons for:

- Allows Artemis to be more easily extended to other platforms
- Consistency with the rest of the codebase (using `with_first_found` to limit which operating systems have extra vars to import)