### PR TITLE
logging/logrotate: add group to su directive, ensure configurations are owned by root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 # **[Unreleased](https://github.com/travisperkins/artemis/compare/v2.0.0...HEAD) (HEAD)**
 
+### logging/logrotate
+- **New:** Include group in **su** directive of logrotate configurations as logrotate requires this unless a default **su** has been specified in **logrotate.conf** - [Richard Lees]
+- **Change:** Ensure logrotate configurations are owned by **root** - [Richard Lees]
+
 ### platform/ntpd
 - **Change**: The discard average value has been changed. By default it is now **3**, for the **balanced** security mode it is now **4** and for the **enhanced** security mode it is now **9** - [Richard Lees]
 - **Change**: The initial manual time sync is now disabled by default. NTPD will take care of making sure the clock is syncronised when it is started. The manual sync can be turned back on by setting **ntpd_set_enabled** to **true** - [Richard Lees]

--- a/logging/logrotate/defaults/main.yml
+++ b/logging/logrotate/defaults/main.yml
@@ -11,7 +11,8 @@ logrotate_dependencies:
 ###################################################################################################
 
 logrotate_retain   : 50
-logrotate_as_user  : '{{ root_user }}'
+logrotate_as_user  : '{{ root_user         }}'
+logrotate_as_group : '{{ logrotate_as_user }}'
 logrotate_frequency: daily
 
 ###################################################################################################
@@ -29,7 +30,7 @@ logrotate_entries:
   - copytruncate
   - delaycompress
   - rotate {{ logrotate_retain    }}
-  - su {{     logrotate_as_user   }}
+  - su {{     logrotate_as_user   }} {{ logrotate_as_group }}
   - '{{       logrotate_frequency }}'
 
 ###################################################################################################

--- a/logging/logrotate/tasks/main.yml
+++ b/logging/logrotate/tasks/main.yml
@@ -66,7 +66,6 @@
   template: src={{ logrotate_src     }}
            dest={{ logrotate_dest    }}
            mode={{ logrotate_mode    }}
-          owner={{ logrotate_as_user }}
 
   tags:
     - artemis


### PR DESCRIPTION
This logrotate refactor includes the following:

- Make sure logrotate configurations (usually kept in `/etc/logrotate.d/`) are owned by **root**. Newer versions of logrotate (quite correctly) fails to run if they are owned by anyone else.
- Include the users *group* in the **su** directive. Unless specified in `/etc/logrotate.conf` the *group* must be specified along with the *user*.

It seems only Debian-based include a group in `/etc/logrotate.conf`. The group set is **syslog** which is generally not relevant to custom logrotate configurations generated by Artemis. If, however, setting the group to **syslog** is relevant this can be done with new variable: `logrotate_as_group`